### PR TITLE
Update to Swift 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  macos:
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        xcode:
+          - "12.4" # Swift 5.3
+
+    name: "macOS (Xcode ${{ matrix.xcode }})"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-xcode-${{ matrix.xcode }}-
+      - name: Build and Test
+        run: swift test -v
+        env:
+          DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode }}.app/Contents/Developer
+
+  linux:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        swift:
+          - "5.3"
+
+    name: "Linux (Swift ${{ matrix.swift }})"
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+          path: .build
+          key: ${{ runner.os }}-spm-swift-${{ matrix.swift }}-${{ hashFiles('**/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-swift-${{ matrix.swift }}-
+      - name: Build and Test
+        run: swift test --enable-test-discovery -v

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.3
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 /*
@@ -20,16 +20,22 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/apple/example-package-deckofplayingcards.git", from: "3.0.0"),
+        .package(name: "DeckOfPlayingCards",
+                 url: "https://github.com/apple/example-package-deckofplayingcards.git",
+                 from: "3.0.0"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "Dealer",
-            dependencies: ["DeckOfPlayingCards"]),
+            dependencies: [
+                .byName(name: "DeckOfPlayingCards")
+            ]),
         .testTarget(
             name: "DealerTests",
-            dependencies: ["Dealer"]),
+            dependencies: [
+                .byName(name: "Dealer")
+            ]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,9 @@ let package = Package(
         .package(name: "DeckOfPlayingCards",
                  url: "https://github.com/apple/example-package-deckofplayingcards.git",
                  from: "3.0.0"),
+        .package(name: "swift-argument-parser",
+                 url: "https://github.com/apple/swift-argument-parser.git",
+                 from: "0.4.4"),
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -30,7 +33,10 @@ let package = Package(
         .target(
             name: "Dealer",
             dependencies: [
-                .byName(name: "DeckOfPlayingCards")
+                .product(name: "DeckOfPlayingCards",
+                         package: "DeckOfPlayingCards"),
+                .product(name: "ArgumentParser",
+                         package: "swift-argument-parser")
             ]),
         .testTarget(
             name: "DealerTests",

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright 2015 Apple Inc. and the Swift project authors
+ Copyright 2015 – 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information

--- a/Package.swift
+++ b/Package.swift
@@ -28,5 +28,8 @@ let package = Package(
         .target(
             name: "Dealer",
             dependencies: ["DeckOfPlayingCards"]),
+        .testTarget(
+            name: "DealerTests",
+            dependencies: ["Dealer"]),
     ]
 )

--- a/Sources/Dealer/FileWrapper+Extensions.swift
+++ b/Sources/Dealer/FileWrapper+Extensions.swift
@@ -1,8 +1,18 @@
-//
-//  File.swift
-//  File
-//
-//  Created by Mattt Zmuda on 8/18/21.
-//
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
 
 import Foundation
+
+extension FileHandle: TextOutputStream {
+    public func write(_ string: String) {
+        guard let data = string.data(using: .utf8) else { return }
+        write(data)
+    }
+}

--- a/Sources/Dealer/FileWrapper+Extensions.swift
+++ b/Sources/Dealer/FileWrapper+Extensions.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  File
+//
+//  Created by Mattt Zmuda on 8/18/21.
+//
+
+import Foundation

--- a/Sources/Dealer/main.swift
+++ b/Sources/Dealer/main.swift
@@ -13,10 +13,21 @@ import Glibc
 srandom(UInt32(clock()))
 #endif
 
+import Foundation
 import DeckOfPlayingCards
 import ArgumentParser
 
+var stdout = FileHandle.standardOutput
+var stderr = FileHandle.standardError
+
 struct Deal: ParsableCommand {
+    static var configuration = CommandConfiguration(
+            abstract: "Shuffles a deck of playing cards and deals a number of cards.",
+            discussion: """
+                Prints each card to stdout until the deck is completely dealt,
+                and prints "No more cards" to stderr if there are no cards remaining.
+                """)
+
     @Argument(help: "The number of cards to deal.")
     var count: UInt = 10
 
@@ -26,11 +37,11 @@ struct Deal: ParsableCommand {
 
         for _ in 0..<count {
             guard let card = deck.deal() else {
-                print("No More Cards!")
+                print("No more cards", to: &stderr)
                 break
             }
 
-            print(card)
+            print(card, to: &stdout)
         }
     }
 }

--- a/Sources/Dealer/main.swift
+++ b/Sources/Dealer/main.swift
@@ -1,7 +1,7 @@
 /*
  This source file is part of the Swift.org open source project
 
- Copyright 2015 Apple Inc. and the Swift project authors
+ Copyright 2015 – 2021 Apple Inc. and the Swift project authors
  Licensed under Apache License v2.0 with Runtime Library Exception
 
  See http://swift.org/LICENSE.txt for license information

--- a/Sources/Dealer/main.swift
+++ b/Sources/Dealer/main.swift
@@ -18,13 +18,13 @@ import ArgumentParser
 
 struct Deal: ParsableCommand {
     @Argument(help: "The number of cards to deal.")
-    var numberOfCards: Int = 10
+    var count: UInt = 10
 
     mutating func run() throws {
         var deck = Deck.standard52CardDeck()
         deck.shuffle()
 
-        for _ in 0..<numberOfCards {
+        for _ in 0..<count {
             guard let card = deck.deal() else {
                 print("No More Cards!")
                 break

--- a/Sources/Dealer/main.swift
+++ b/Sources/Dealer/main.swift
@@ -14,17 +14,25 @@ srandom(UInt32(clock()))
 #endif
 
 import DeckOfPlayingCards
+import ArgumentParser
 
-let numberOfCards = 10
+struct Deal: ParsableCommand {
+    @Argument(help: "The number of cards to deal.")
+    var numberOfCards: Int = 10
 
-var deck = Deck.standard52CardDeck()
-deck.shuffle()
+    mutating func run() throws {
+        var deck = Deck.standard52CardDeck()
+        deck.shuffle()
 
-for _ in 0..<numberOfCards {
-    guard let card = deck.deal() else {
-        print("No More Cards!")
-        break
+        for _ in 0..<numberOfCards {
+            guard let card = deck.deal() else {
+                print("No More Cards!")
+                break
+            }
+
+            print(card)
+        }
     }
-
-    print(card)
 }
+
+Deal.main()

--- a/Tests/DealerTests/DealerTests.swift
+++ b/Tests/DealerTests/DealerTests.swift
@@ -1,0 +1,57 @@
+/*
+ This source file is part of the Swift.org open source project
+
+ Copyright 2021 Apple Inc. and the Swift project authors
+ Licensed under Apache License v2.0 with Runtime Library Exception
+
+ See http://swift.org/LICENSE.txt for license information
+ See http://swift.org/CONTRIBUTORS.txt for Swift project authors
+*/
+
+import XCTest
+import class Foundation.Bundle
+
+final class DealerTests: XCTestCase {
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct
+        // results.
+
+        // Some of the APIs that we use below are available in macOS 10.13 and above.
+        guard #available(macOS 10.13, *) else {
+            return
+        }
+
+        // Mac Catalyst won't have `Process`, but it is supported for executables.
+        #if !targetEnvironment(macCatalyst)
+
+        let dealerBinary = productsDirectory.appendingPathComponent("Dealer")
+
+        let process = Process()
+        process.executableURL = dealerBinary
+
+        let pipe = Pipe()
+        process.standardOutput = pipe
+
+        try process.run()
+        process.waitUntilExit()
+
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        let output = String(data: data, encoding: .utf8)
+
+        XCTAssertNotEqual(output, "")
+        #endif
+    }
+
+    /// Returns path to the built products directory.
+    var productsDirectory: URL {
+      #if os(macOS)
+        for bundle in Bundle.allBundles where bundle.bundlePath.hasSuffix(".xctest") {
+            return bundle.bundleURL.deletingLastPathComponent()
+        }
+        fatalError("couldn't find the products directory")
+      #else
+        return Bundle.main.bundleURL
+      #endif
+    }
+}


### PR DESCRIPTION
Depends on #5 

This PR updates the package manifest to `swift-tools-version:5.3` makes the following changes for Swift 5:

- Adds dependency on [swift-argument-parser](https://github.com/apple/swift-argument-parser)
- Write "No more cards" to `stderr` instead of `stdout`
- Miscellaneous stylistic refinements
