### PR TITLE
Fix usage output

### DIFF
--- a/Sources/dealer/Dealer.swift
+++ b/Sources/dealer/Dealer.swift
@@ -18,7 +18,7 @@ import PlayingCard
 import ArgumentParser
 
 @main
-struct Deal: ParsableCommand {
+struct Dealer: ParsableCommand {
     enum Error: Swift.Error, CustomStringConvertible {
         case notEnoughCards
 


### PR DESCRIPTION
Currently if run with `swift run` script outputs:
```
Error: Missing expected argument '<count> ...'

OVERVIEW: Shuffles a deck of playing cards and deals a number of cards.

For each count argument, prints a line of tab-delimited cards to stdout,
or if there aren't enough cards remaining,
prints "Not enough cards" to stderr and exits with a nonzero status.

USAGE: deal [<count> ...]

ARGUMENTS:
  <count>                 The number of cards to deal at a time.

OPTIONS:
  -h, --help              Show help information.
```

Part "USAGE: deal" is misleading. It should be "USAGE: dealer".
